### PR TITLE
Add Dockerfiles for Ubuntu rolling, devel, latest

### DIFF
--- a/Dockerfiles/Dockerfile.aarch64.ubuntu22.04
+++ b/Dockerfiles/Dockerfile.aarch64.ubuntu22.04
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:20.04
+FROM arm64v8/ubuntu:22.04
 
 COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
 RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.aarch64.ubuntu_devel
+++ b/Dockerfiles/Dockerfile.aarch64.ubuntu_devel
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:20.04
+FROM arm64v8/ubuntu:devel
 
 COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
 RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.aarch64.ubuntu_latest
+++ b/Dockerfiles/Dockerfile.aarch64.ubuntu_latest
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:20.04
+FROM arm64v8/ubuntu:latest
 
 COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
 RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.aarch64.ubuntu_rolling
+++ b/Dockerfiles/Dockerfile.aarch64.ubuntu_rolling
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:20.04
+FROM arm64v8/ubuntu:rolling
 
 COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
 RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.armv7.ubuntu22.04
+++ b/Dockerfiles/Dockerfile.armv7.ubuntu22.04
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:20.04
+FROM arm32v7/ubuntu:22.04
 
 COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
 RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.armv7.ubuntu_devel
+++ b/Dockerfiles/Dockerfile.armv7.ubuntu_devel
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:20.04
+FROM arm32v7/ubuntu:devel
 
 COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
 RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.armv7.ubuntu_latest
+++ b/Dockerfiles/Dockerfile.armv7.ubuntu_latest
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:20.04
+FROM arm32v7/ubuntu:latest
 
 COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
 RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.armv7.ubuntu_rolling
+++ b/Dockerfiles/Dockerfile.armv7.ubuntu_rolling
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:20.04
+FROM arm32v7/ubuntu:rolling
 
 COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
 RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.ppc64le.ubuntu22.04
+++ b/Dockerfiles/Dockerfile.ppc64le.ubuntu22.04
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:20.04
+FROM ppc64le/ubuntu:22.04
 
 COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
 RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.ppc64le.ubuntu_devel
+++ b/Dockerfiles/Dockerfile.ppc64le.ubuntu_devel
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:20.04
+FROM ppc64le/ubuntu:devel
 
 COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
 RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.ppc64le.ubuntu_latest
+++ b/Dockerfiles/Dockerfile.ppc64le.ubuntu_latest
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:20.04
+FROM ppc64le/ubuntu:latest
 
 COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
 RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.ppc64le.ubuntu_rolling
+++ b/Dockerfiles/Dockerfile.ppc64le.ubuntu_rolling
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:20.04
+FROM ppc64le/ubuntu:rolling
 
 COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
 RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.s390x.ubuntu22.04
+++ b/Dockerfiles/Dockerfile.s390x.ubuntu22.04
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:20.04
+FROM s390x/ubuntu:22.04
 
 COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
 RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.s390x.ubuntu_devel
+++ b/Dockerfiles/Dockerfile.s390x.ubuntu_devel
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:20.04
+FROM s390x/ubuntu:devel
 
 COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
 RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.s390x.ubuntu_latest
+++ b/Dockerfiles/Dockerfile.s390x.ubuntu_latest
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:20.04
+FROM s390x/ubuntu:latest
 
 COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
 RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.s390x.ubuntu_rolling
+++ b/Dockerfiles/Dockerfile.s390x.ubuntu_rolling
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:20.04
+FROM s390x/ubuntu:rolling
 
 COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
 RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh


### PR DESCRIPTION
This adds the Dockerfiles for Ubuntu:latest, Ubuntu:rolling, Ubuntu:devel and Ubuntu:22.04 for the architectures aarch64, arm32v7, ppc64le and s390x.